### PR TITLE
ci: update github actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+
+- Updated actions:
+  - actions/upload-artifact@v4 -> actions/upload-artifact@v7
+  - actions/github-script@v7 -> actions/github-script@v8
+  - peter-evans/find-comment@v3 -> peter-evans/find-comment@v4
+  - peter-evans/create-or-update-comment@v4 -> peter-evans/create-or-update-comment@v5
 
 ## [1.9.2] - 2026-04-07
 

--- a/action.yml
+++ b/action.yml
@@ -175,7 +175,7 @@ runs:
 
     - name: CAR file artifact upload
       if: ${{ inputs.upload-car-artifact != 'false' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ env.artifact_name }}
         path: build.car
@@ -323,7 +323,7 @@ runs:
 
     - name: Set GitHub commit status
       if: ${{ inputs.set-github-status == 'true' }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -355,7 +355,7 @@ runs:
     - name: Get PR number for workflow_run
       if: ${{ inputs.set-pr-comment == 'true' && github.event_name == 'workflow_run' }}
       id: pr-number
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -367,11 +367,11 @@ runs:
               head: `${context.payload.workflow_run.head_repository.owner.login}:${context.payload.workflow_run.head_branch}`,
               state: 'open'
             });
-            
+
             if (pulls.data.length > 0) {
               // Try to find the PR whose head SHA matches the workflow run's head_sha
               const matchingPr = pulls.data.find(pr => pr.head.sha === context.payload.workflow_run.head_sha);
-              
+
               if (matchingPr) {
                 core.setOutput('number', matchingPr.number);
                 core.setOutput('sha', matchingPr.head.sha);
@@ -388,7 +388,7 @@ runs:
 
     - name: Find Comment to update
       if: ${{ inputs.set-pr-comment == 'true' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target' || (github.event_name == 'workflow_run' && steps.pr-number.outputs.number)) }}
-      uses: peter-evans/find-comment@v3
+      uses: peter-evans/find-comment@v4
       id: fc
       with:
         issue-number: ${{ github.event.pull_request.number || steps.pr-number.outputs.number }}
@@ -398,7 +398,7 @@ runs:
 
     - name: Create or update comment
       if: ${{ inputs.set-pr-comment == 'true' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target' || (github.event_name == 'workflow_run' && steps.pr-number.outputs.number)) }}
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@v5
       with:
         token: ${{ inputs.github-token }}
         comment-id: ${{ steps.fc.outputs.comment-id }}


### PR DESCRIPTION
This PR updates actions within the repository. The changelog do not suggest any breaking changes beyond moving to Node 24 runtime.