### PR TITLE
docs: add Filecoin Pin Action composition example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- README: `Archiving to Filecoin` section showing how to chain [`filecoin-project/filecoin-pin`](https://github.com/filecoin-project/filecoin-pin) after this action to archive the same CAR to Filecoin. Requires an upstream release that treats a `.car` `path` as a pre-built CAR ([filecoin-project/filecoin-pin#410](https://github.com/filecoin-project/filecoin-pin/pull/410)).
+- README: new `Archiving to Filecoin` section. Chains the [`filecoin-pin`](https://github.com/filecoin-project/filecoin-pin) CLI (>=0.20.1) after this action to archive `build.car` without repacking, preserving the root CID. Uses `filecoin-pin import --auto-fund` with `--min-runway-days` and `--max-balance` to cap wallet spend per run.
 
 ## [1.9.2] - 2026-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- README: `Archiving to Filecoin` section showing how to chain [`filecoin-project/filecoin-pin`](https://github.com/filecoin-project/filecoin-pin) after this action to archive the same CAR to Filecoin. Requires an upstream release that treats a `.car` `path` as a pre-built CAR ([filecoin-project/filecoin-pin#410](https://github.com/filecoin-project/filecoin-pin/pull/410)).
+
 ## [1.9.2] - 2026-04-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The [composite action](https://docs.github.com/en/actions/sharing-automations/cr
 - [Usage](#usage)
   - [Simple Workflow (No Fork PRs)](#simple-workflow-no-fork-prs)
   - [Dual Workflows (With Fork PRs)](#dual-workflows-with-fork-prs)
+  - [Archiving to Filecoin](#archiving-to-filecoin)
 - [FAQ](#faq)
 
 ## Features
@@ -287,6 +288,38 @@ jobs:
 See real-world examples:
 - [IPFS Specs](https://github.com/ipfs/specs/tree/main/.github/workflows) - Uses the secure two-workflow pattern
 - [IPFS Docs](https://github.com/ipfs/ipfs-docs/tree/main/.github/workflows) - Uses the secure two-workflow pattern
+
+### Archiving to Filecoin
+
+The CAR file produced by this action can be archived to the Filecoin network via [`filecoin-project/filecoin-pin`](https://github.com/filecoin-project/filecoin-pin). That keeps the same root CID and layers Filecoin storage deals on top of whichever hot-pinning provider you already use above. The action below uploads a pre-built CAR when `path` ends in `.car`, so no repacking is needed and the CID is unchanged. Wallet funding (FIL for gas, USDFC for storage) is the user's responsibility; see the upstream [security checklist](https://github.com/filecoin-project/filecoin-pin/tree/master/upload-action#security-checklist).
+
+Add the archival step to a simple workflow. `build.car` is left in the runner workspace by this action, so later steps in the same job can read it directly:
+
+```yaml
+      - name: Deploy to IPFS
+        id: deploy
+        uses: ipfs/ipfs-deploy-action@v1
+        with:
+          path-to-deploy: out
+          cluster-url: ${{ secrets.CLUSTER_URL }}
+          cluster-user: ${{ secrets.CLUSTER_USER }}
+          cluster-password: ${{ secrets.CLUSTER_PASSWORD }}
+          github-token: ${{ github.token }}
+
+      - name: Archive CAR to Filecoin
+        # Fence fork PRs off from the wallet-spending step: run only for same-repo
+        # events so non-maintainer PR authors cannot trigger deposits.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+        uses: filecoin-project/filecoin-pin/upload-action@v0
+        with:
+          path: build.car
+          walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}
+          network: mainnet
+          minStorageDays: '30'
+          filecoinPayBalanceLimit: '5.00'
+```
+
+For the dual-workflow pattern, add the archival step to `deploy.yml` after the existing `Deploy to IPFS` step. The CAR is available at `build.car` for the duration of the job. For the highest assurance with mainnet wallets, put the archival step in its own job gated by a GitHub [Environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/managing-environments-for-deployment) with required reviewers, so no workflow change merges wallet access without human approval.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -291,9 +291,9 @@ See real-world examples:
 
 ### Archiving to Filecoin
 
-The CAR file produced by this action can be archived to the Filecoin network via [`filecoin-project/filecoin-pin`](https://github.com/filecoin-project/filecoin-pin). That keeps the same root CID and layers Filecoin storage deals on top of whichever hot-pinning provider you already use above. The action below uploads a pre-built CAR when `path` ends in `.car`, so no repacking is needed and the CID is unchanged. Wallet funding (FIL for gas, USDFC for storage) is the user's responsibility; see the upstream [security checklist](https://github.com/filecoin-project/filecoin-pin/tree/master/upload-action#security-checklist).
+Archive the CAR this action produces to Filecoin with the [`filecoin-pin`](https://github.com/filecoin-project/filecoin-pin) CLI (>=0.20.1). `filecoin-pin import` consumes `build.car` from the runner workspace without repacking, so the root CID stays identical and the Filecoin storage deal layers on top of whichever hot-pinning provider you use above. You provision the wallet (FIL for gas, USDFC for storage); see the [filecoin-pin docs](https://github.com/filecoin-project/filecoin-pin#getting-started).
 
-Add the archival step to a simple workflow. `build.car` is left in the runner workspace by this action, so later steps in the same job can read it directly:
+Add the archival step to a simple workflow:
 
 ```yaml
       - name: Deploy to IPFS
@@ -307,19 +307,22 @@ Add the archival step to a simple workflow. `build.car` is left in the runner wo
           github-token: ${{ github.token }}
 
       - name: Archive CAR to Filecoin
-        # Fence fork PRs off from the wallet-spending step: run only for same-repo
-        # events so non-maintainer PR authors cannot trigger deposits.
+        # Block fork PRs from this wallet-spending step: same-repo events only,
+        # so non-maintainer authors cannot trigger deposits.
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-        uses: filecoin-project/filecoin-pin/upload-action@v0
-        with:
-          path: build.car
-          walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}
-          network: mainnet
-          minStorageDays: '30'
-          filecoinPayBalanceLimit: '5.00'
+        env:
+          PRIVATE_KEY: ${{ secrets.FILECOIN_WALLET_KEY }}
+        run: |
+          npx -y filecoin-pin import build.car \
+            --mainnet \
+            --auto-fund \
+            --min-runway-days 30 \
+            --max-balance 5.0
 ```
 
-For the dual-workflow pattern, add the archival step to `deploy.yml` after the existing `Deploy to IPFS` step. The CAR is available at `build.car` for the duration of the job. For the highest assurance with mainnet wallets, put the archival step in its own job gated by a GitHub [Environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/managing-environments-for-deployment) with required reviewers, so no workflow change merges wallet access without human approval.
+`--auto-fund` enables `--min-runway-days` and `--max-balance`, which cap the USDFC deposit per run. Pin a specific `filecoin-pin` version (`npx -y filecoin-pin@<version>`) once you have validated it against your wallet, so a wallet-spending step never picks up a new release without an explicit bump.
+
+For the dual-workflow pattern, add the archival step to `deploy.yml` after the existing `Deploy to IPFS` step; `build.car` persists for the rest of the job. For maximum safety with mainnet wallets, isolate the archival step in its own job gated by a GitHub [Environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/managing-environments-for-deployment) with required reviewers, so no workflow change merges wallet access without human approval.
 
 ## FAQ
 


### PR DESCRIPTION
> [!IMPORTANT]
> do not merge, opening to illustrate how we can keep filecoin-pin details separate, without any maintenance burden.

## What

Adds a `Archiving to Filecoin` README section showing how to chain [`filecoin-project/filecoin-pin/upload-action`](https://github.com/filecoin-project/filecoin-pin/tree/master/upload-action) after this action so the same CAR is archived to Filecoin. No `action.yml` changes.

- Closes #39

## Why composition, not embedding

I prototyped embedding Filecoin Pin as a first-class provider and it does not look feasible in current state of upstream code:

- **Complexity.** Other providers have CLI which allow us to havee one-liners in `action.yml`. Filecoin Pin is ~400 lines of Node.js (Synapse, USDFC top-ups, PDP, IPNI, retry). Not sane. We could revisit if upstream provides better CLI tooling that blackboxes process end-to-end.
- **Permissions.** Upstream needs `checks: write`, `pull-requests: write`, `actions: read` for its own check run / PR comment / artifact cache. Every caller would have to grant those, even if they never enable Filecoin. Not feasible, bad opsec.
- **Alpha churn.** Upstream's README flags the upload-action as an "educational demo" with breaking changes expected. Embedding ties our release cadence to theirs. Maintenance burden.
- **Duplicate PR comments.** Upstream already posts its own (piece CID, data set, provider, retrieval URL). Deduping needs another upstream change.

Composition (this PR) scopes all four to users who actually opt in.

## Today vs. after upstream #410

Example works today, but upstream repacks the CAR so the Filecoin CID will differ from ours. Once [filecoin-project/filecoin-pin#410](https://github.com/filecoin-project/filecoin-pin/pull/410) ships, switching to `path: build.car` makes the CIDs identical.

## Revisit when

Filecoin Pin ships a shell-level one-liner comparable to `ipfs pin remote add` (Pinata) or `aws s3 cp --metadata 'import=car'` (Filebase). Then embedding becomes cheap and the argument flips.