### PR TITLE
feat: add Filecoin upload via filecoin-pin CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The [composite action](https://docs.github.com/en/actions/sharing-automations/cr
 - 🚀 Uploads CAR file to either IPFS Cluster or a single Kubo instance
 - 📍 Optional pinning to Pinata
 - 💾 Optional CAR file upload to Filebase
+- 📦 Optional CAR file upload to Filecoin via [filecoin-pin](https://github.com/filecoin-project/filecoin-pin) CLI
 - 📤 CAR file attached to Github Action run Summary page
 - 🔗 Automatic preview links
 - 💬 Optional PR comments with CID and preview links
@@ -86,6 +87,16 @@ This action encapsulates the established best practices for deploying static sit
 | `filebase-access-key` | Filebase access key |
 | `filebase-secret-key` | Filebase secret key |
 | `filebase-bucket`     | Filebase bucket name |
+
+#### Filecoin
+
+Uploads the CAR file to Filecoin via the [filecoin-pin](https://github.com/filecoin-project/filecoin-pin) CLI. Funds (USDFC) and Filecoin Pay approvals must already be set up on the wallet — see filecoin-pin's `payments setup` / `payments deposit` commands.
+
+| Input                          | Description                                                                                                | Default        |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------- | -------------- |
+| `filecoin-wallet-private-key`  | Wallet private key used to fund Filecoin uploads (USDFC). Setting this enables the Filecoin upload step.   |                |
+| `filecoin-network`             | Filecoin network: `mainnet` or `calibration`.                                                              | `calibration`  |
+| `filecoin-pin-version`         | Version of `filecoin-pin` CLI to install from npm.                                                         | `latest`       |
 
 #### Storacha (deprecated)
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Uploads the CAR file to Filecoin via the [filecoin-pin](https://github.com/filec
 | Input                          | Description                                                                                                | Default        |
 | ------------------------------ | ---------------------------------------------------------------------------------------------------------- | -------------- |
 | `filecoin-wallet-private-key`  | Wallet private key used to fund Filecoin uploads (USDFC). Setting this enables the Filecoin upload step.   |                |
-| `filecoin-network`             | Filecoin network: `mainnet` or `calibration`.                                                              | `calibration`  |
+| `filecoin-network`             | Filecoin network: `mainnet` or `calibration`.                                                              | `mainnet`      |
 | `filecoin-pin-version`         | Version of `filecoin-pin` CLI to install from npm.                                                         | `latest`       |
 
 #### Storacha (deprecated)

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,17 @@ inputs:
   filebase-secret-key:
     description: 'Filebase secret key'
     required: false
+  filecoin-wallet-private-key:
+    description: 'Wallet private key used to fund Filecoin uploads (USDFC on Calibration/Mainnet). Setting this enables Filecoin upload via the filecoin-pin CLI.'
+    required: false
+  filecoin-network:
+    description: 'Filecoin network to use. Either "mainnet" or "calibration".'
+    default: 'calibration'
+    required: false
+  filecoin-pin-version:
+    description: 'Version of filecoin-pin CLI to install from npm (e.g. "0.20.0" or "latest").'
+    default: 'latest'
+    required: false
   github-token:
     description: 'GitHub token for updating commit status and PR comments'
     required: true
@@ -106,8 +117,9 @@ runs:
         # 2. IPFS Cluster: url, user and password must all be set
         # 3. Kubo: api url and auth must both be set
         # 4. Filebase: access key, secret key, and bucket must all be set
-        if [[ -z "${{ inputs.storacha-key }}" || -z "${{ inputs.storacha-proof }}" ]] && [[ -z "${{ inputs.cluster-url }}" || -z "${{ inputs.cluster-user }}" || -z "${{ inputs.cluster-password }}" ]] && [[ -z "${{ inputs.kubo-api-url }}" || -z "${{ inputs.kubo-api-auth }}" ]] && [[ -z "${{ inputs.filebase-access-key }}" || -z "${{ inputs.filebase-secret-key }}" || -z "${{ inputs.filebase-bucket }}" ]]; then
-          MSG="At least one CAR upload provider must be configured: IPFS Cluster (cluster-url, cluster-user, cluster-password), Kubo (kubo-api-url, kubo-api-auth), or Filebase (filebase-access-key, filebase-secret-key, filebase-bucket)."
+        # 5. Filecoin: wallet private key must be set
+        if [[ -z "${{ inputs.storacha-key }}" || -z "${{ inputs.storacha-proof }}" ]] && [[ -z "${{ inputs.cluster-url }}" || -z "${{ inputs.cluster-user }}" || -z "${{ inputs.cluster-password }}" ]] && [[ -z "${{ inputs.kubo-api-url }}" || -z "${{ inputs.kubo-api-auth }}" ]] && [[ -z "${{ inputs.filebase-access-key }}" || -z "${{ inputs.filebase-secret-key }}" || -z "${{ inputs.filebase-bucket }}" ]] && [[ -z "${{ inputs.filecoin-wallet-private-key }}" ]]; then
+          MSG="At least one CAR upload provider must be configured: IPFS Cluster (cluster-url, cluster-user, cluster-password), Kubo (kubo-api-url, kubo-api-auth), Filebase (filebase-access-key, filebase-secret-key, filebase-bucket), or Filecoin (filecoin-wallet-private-key)."
           if [[ -n "${{ inputs.pinata-jwt-token }}" ]]; then
             MSG="${MSG} Pinata cannot be the sole provider until CAR upload support is tested (see https://github.com/ipshipyard/ipfs-deploy-action/pull/42)."
           fi
@@ -312,6 +324,29 @@ runs:
           echo "::error::Failed to upload to Filebase"
           exit 1
         fi
+
+    - name: Set up Node.js for Filecoin
+      if: ${{ inputs.filecoin-wallet-private-key != '' }}
+      uses: actions/setup-node@v6
+      with:
+        node-version: '24.x'
+
+    - name: Upload CAR to Filecoin
+      if: ${{ inputs.filecoin-wallet-private-key != '' }}
+      shell: bash
+      env:
+        PRIVATE_KEY: ${{ inputs.filecoin-wallet-private-key }}
+        NETWORK: ${{ inputs.filecoin-network }}
+      run: |
+        echo "ℹ️ Installing filecoin-pin@${{ inputs.filecoin-pin-version }}"
+        npm install -g "filecoin-pin@${{ inputs.filecoin-pin-version }}"
+
+        echo "ℹ️ Uploading CAR with CID ${{ steps.merkleize.outputs.cid }} to Filecoin (${NETWORK})"
+        if ! filecoin-pin import build.car --network "${NETWORK}"; then
+          echo "::error::Failed to upload CAR to Filecoin"
+          exit 1
+        fi
+        echo "✅ Uploaded CAR with CID \`${{ steps.merkleize.outputs.cid }}\` to Filecoin (${NETWORK})" >> $GITHUB_STEP_SUMMARY
 
     - name: Pin CID to Pinata
       if: ${{ inputs.pinata-jwt-token != ''}}

--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ inputs:
     required: false
   filecoin-network:
     description: 'Filecoin network to use. Either "mainnet" or "calibration".'
-    default: 'calibration'
+    default: 'mainnet'
     required: false
   filecoin-pin-version:
     description: 'Version of filecoin-pin CLI to install from npm (e.g. "0.20.0" or "latest").'


### PR DESCRIPTION
> [!NOTE]
> Draft. Counterpoint to #49. Same goal (Filecoin support), different shape.

cc @lidel @biglep

Adds an optional Filecoin upload step that shells out to the `filecoin-pin` CLI on the existing `build.car`. No new build dependency on the consumer's repo, no `pnpm`/workspace coupling like the embedded `upload-action`.

Verified end-to-end on filecoin-pin-website: filecoin-project/filecoin-pin-website#174. Uploaded to calibration, both copies confirmed on-chain, IPNI records published.

## What changes

- Three new inputs: `filecoin-wallet-private-key`, `filecoin-network` (default `mainnet`), `filecoin-pin-version` (default `latest`).
- One step: `npm i -g filecoin-pin@<ver> && filecoin-pin import build.car --network <net>`.
- Validation: Filecoin counts as a valid sole provider.
- README entry under existing provider sections.

## Scope / non-goals

- No funding logic. Caller sets up USDFC + Filecoin Pay approvals beforehand (`filecoin-pin payments setup` / `deposit`). If runway is too low, `import` fails loudly.
- No `pieceCid` / `dataSetId` outputs yet. CLI doesn't emit JSON. Happy to add stdout parsing or wait for a `--json` flag in filecoin-pin.
- No CDN flag.

## Re: #49

Agree composition is fine for advanced users. This PR is for the path where folks want a single step alongside Storacha/Cluster/Filebase, without learning a second action. CLI-based instead of importing `filecoin-pin` as a library, sidesteps the workspace/build-coupling concerns raised in #49.

Open to closing this in favor of #49 if you'd rather keep `action.yml` lean.