### PR TITLE
feat: add filecoin-pin CLI as built-in CAR upload provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `filecoin-pin` as a first-class CAR upload provider alongside IPFS Cluster, Kubo, and Filebase. Set `filecoin-wallet-key`, `filecoin-min-runway-days`, and `filecoin-max-balance` to upload the CAR to a Filecoin storage provider via Synapse + USDFC; the root CID is kept identical (no repacking). Fork PRs skip the step so untrusted contributors cannot trigger wallet deposits. Defaults to upstream [filecoin-pin v0.20.1](https://github.com/filecoin-project/filecoin-pin/releases/tag/v0.20.1); bump via `filecoin-pin-version` after testing with your wallet.
+
 ## [1.9.2] - 2026-04-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Deploy to IPFS Action
 
-This GitHub Action automates the deployment of static sites to IPFS using [CAR files](https://docs.ipfs.tech/concepts/glossary/#car). It pins to either [IPFS Cluster](https://ipfscluster.io/) or a single [Kubo](https://github.com/ipfs/kubo) instance, as well as supporting additional pinning to [Pinata](https://pinata.cloud) and [Filebase](https://filebase.com). The action will automatically create a preview link and update your PR/commit status with the deployment information.
+This GitHub Action automates the deployment of static sites to IPFS using [CAR files](https://docs.ipfs.tech/concepts/glossary/#car). It pins to one or more of [IPFS Cluster](https://ipfscluster.io/), a single [Kubo](https://github.com/ipfs/kubo) instance, [Filebase](https://filebase.com), or the Filecoin network via [`filecoin-pin`](https://github.com/filecoin-project/filecoin-pin), with optional [Pinata](https://pinata.cloud) pinning. The action will automatically create a preview link and update your PR/commit status with the deployment information.
 
 This action is built and maintained by [Interplanetary Shipyard](https://ipshipyard.com/).
 <a href="https://ipshipyard.com/"><img align="right" src="https://github.com/user-attachments/assets/39ed3504-bb71-47f6-9bf8-cb9a1698f272" /></a>
@@ -22,6 +22,7 @@ The [composite action](https://docs.github.com/en/actions/sharing-automations/cr
 - [Usage](#usage)
   - [Simple Workflow (No Fork PRs)](#simple-workflow-no-fork-prs)
   - [Dual Workflows (With Fork PRs)](#dual-workflows-with-fork-prs)
+  - [Filecoin Pin](#filecoin-pin-1)
 - [FAQ](#faq)
 
 ## Features
@@ -30,6 +31,7 @@ The [composite action](https://docs.github.com/en/actions/sharing-automations/cr
 - 🚀 Uploads CAR file to either IPFS Cluster or a single Kubo instance
 - 📍 Optional pinning to Pinata
 - 💾 Optional CAR file upload to Filebase
+- 🗄️ Optional CAR upload to Filecoin via `filecoin-pin` (preserves root CID; skipped on fork PRs)
 - 📤 CAR file attached to Github Action run Summary page
 - 🔗 Automatic preview links
 - 💬 Optional PR comments with CID and preview links
@@ -42,6 +44,7 @@ This action encapsulates the established best practices for deploying static sit
 - Merkleizes the build into a CAR file in GitHub Actions using Kubo. This ensures that the CID is generated in the build process and is the same across multiple providers.
 - Uploads the CAR file to IPFS via IPFS Cluster or a single Kubo instance.
 - Optionally pins the CID of the CAR file to Pinata. This is useful for redundancy (multiple providers). The pinning here is done in the background and non-blocking.
+- Optionally uploads the CAR to a Filecoin storage provider via [`filecoin-pin`](https://github.com/filecoin-project/filecoin-pin) for long-term storage. Preserves the root CID. Fork PRs skip this step so untrusted contributors cannot trigger wallet deposits.
 - Updates the PR/commit status with the deployment information and preview links.
 
 ## Inputs
@@ -76,6 +79,18 @@ This action encapsulates the established best practices for deploying static sit
 | --------------- | ---------------------------------------------------------------------------------------------------- |
 | `kubo-api-url`  | Kubo RPC API URL to pass to `ipfs --api`, e.g. `/dns/YOUR_DOMAIN/tcp/443/https`                      |
 | `kubo-api-auth` | Kubo RPC API auth secret to pass to `ipfs --api-auth`, e.g. `basic:hello:world` (defined as `AuthSecret` in `API.Authorizations` config) |
+
+#### Filecoin Pin
+
+[github.com/filecoin-project/filecoin-pin](https://github.com/filecoin-project/filecoin-pin) (>=0.20.1)
+
+Uploads the CAR to a Filecoin storage provider via Synapse + USDFC, preserving the root CID. Fork PRs skip this step so untrusted contributors cannot drain your wallet. Fund the wallet yourself (FIL for gas, USDFC for storage); see the [filecoin-pin docs](https://github.com/filecoin-project/filecoin-pin#getting-started). Retrieval goes through Filecoin storage providers (PDP/IPNI), not the hot HTTP gateways shown in preview links above. Pair with another provider if you also want fast preview-link retrieval.
+
+| Input                      | Description                                                                                                                       |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `filecoin-wallet-key`      | Filecoin wallet private key. Enables Filecoin upload; both spend caps below then become required.                                 |
+| `filecoin-min-runway-days` | Required when `filecoin-wallet-key` is set. Minimum storage runway in days that `--auto-fund` should maintain. No default: this caps wallet spend per run, so you must choose. |
+| `filecoin-max-balance`     | Required when `filecoin-wallet-key` is set. Cap on USDFC balance after deposit. No default: this caps wallet spend per run, so you must choose. |
 
 #### Filebase
 
@@ -115,6 +130,8 @@ This action encapsulates the established best practices for deploying static sit
 | `cluster-timeout-minutes` | Timeout in minutes for each IPFS Cluster upload attempt                                                                                             | `'2'`                                      |
 | `cluster-pin-expire-in`   | Time duration after which the pin will expire in IPFS Cluster (e.g. 720h for 30 days). If unset, the CID will be pinned with no expiry.             | -                                          |
 | `pin-name`                | Custom name for the pin. If unset, defaults to "{repo-name}-{commit-sha-short}" for both IPFS Cluster and Pinata.                                   | -                                          |
+| `filecoin-network`        | Filecoin network for `filecoin-pin`: `mainnet` or `calibnet`                                                                                        | `'mainnet'`                                |
+| `filecoin-pin-version`    | Pinned `filecoin-pin` npm version. Bump only after testing with your wallet.                                                                        | `'0.20.1'`                                 |
 
 ## Outputs
 
@@ -287,6 +304,26 @@ jobs:
 See real-world examples:
 - [IPFS Specs](https://github.com/ipfs/specs/tree/main/.github/workflows) - Uses the secure two-workflow pattern
 - [IPFS Docs](https://github.com/ipfs/ipfs-docs/tree/main/.github/workflows) - Uses the secure two-workflow pattern
+
+### Filecoin Pin
+
+To upload the CAR to a Filecoin storage provider alongside (or instead of) the providers above, set `filecoin-wallet-key` and the two spend caps. The root CID stays the same (no repacking), and fork PRs skip this step automatically.
+
+```yaml
+      - name: Deploy to IPFS
+        uses: ipfs/ipfs-deploy-action@v1
+        with:
+          path-to-deploy: out
+          cluster-url: ${{ secrets.CLUSTER_URL }}
+          cluster-user: ${{ secrets.CLUSTER_USER }}
+          cluster-password: ${{ secrets.CLUSTER_PASSWORD }}
+          github-token: ${{ github.token }}
+          filecoin-wallet-key: ${{ secrets.FILECOIN_WALLET_KEY }}
+          filecoin-min-runway-days: '30'
+          filecoin-max-balance: '5.0'
+```
+
+Fund the wallet with FIL (gas) and USDFC (storage); see the [filecoin-pin docs](https://github.com/filecoin-project/filecoin-pin#getting-started). For mainnet wallets, gate the entire deploy job behind a GitHub [Environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/managing-environments-for-deployment) with required reviewers, so no PR can touch your wallet without a human signing off.
 
 ## FAQ
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Deploy to IPFS'
-description: 'Merkleize and deploy static sites to IPFS with Storacha, with optional Pinata and Filebase pinning'
+description: 'Merkleize and deploy static sites to IPFS via IPFS Cluster, Kubo, Filebase, or filecoin-pin, with optional Pinata pinning'
 branding:
   icon: 'box'
   color: 'blue'
@@ -61,6 +61,23 @@ inputs:
   pinata-jwt-token:
     description: 'Pinata JWT token for authentication'
     required: false
+  filecoin-wallet-key:
+    description: 'Filecoin wallet private key (passed via PRIVATE_KEY env). Enables CAR upload to a Filecoin storage provider via filecoin-pin import. Fund the wallet with FIL (gas) and USDFC (storage). Fork PRs skip this step so untrusted contributors cannot trigger wallet deposits.'
+    required: false
+  filecoin-network:
+    description: 'Filecoin network for filecoin-pin: mainnet or calibnet'
+    default: 'mainnet'
+    required: false
+  filecoin-min-runway-days:
+    description: 'Minimum storage runway in days that filecoin-pin --auto-fund should maintain. Required when filecoin-wallet-key is set. No default: this caps wallet spend per run, so the choice must be explicit.'
+    required: false
+  filecoin-max-balance:
+    description: 'Cap on Filecoin Pay USDFC balance after deposit. Required when filecoin-wallet-key is set. No default: this caps wallet spend per run, so the choice must be explicit.'
+    required: false
+  filecoin-pin-version:
+    description: 'filecoin-pin npm version to use. Defaults to a known-good release; bump only after testing with your wallet.'
+    default: '0.20.1'
+    required: false
   filebase-bucket:
     description: 'Filebase bucket name'
     required: false
@@ -105,9 +122,10 @@ runs:
         # 1. Storacha: both key and proof must be set (deprecated, shutting down April 15, 2026)
         # 2. IPFS Cluster: url, user and password must all be set
         # 3. Kubo: api url and auth must both be set
-        # 4. Filebase: access key, secret key, and bucket must all be set
-        if [[ -z "${{ inputs.storacha-key }}" || -z "${{ inputs.storacha-proof }}" ]] && [[ -z "${{ inputs.cluster-url }}" || -z "${{ inputs.cluster-user }}" || -z "${{ inputs.cluster-password }}" ]] && [[ -z "${{ inputs.kubo-api-url }}" || -z "${{ inputs.kubo-api-auth }}" ]] && [[ -z "${{ inputs.filebase-access-key }}" || -z "${{ inputs.filebase-secret-key }}" || -z "${{ inputs.filebase-bucket }}" ]]; then
-          MSG="At least one CAR upload provider must be configured: IPFS Cluster (cluster-url, cluster-user, cluster-password), Kubo (kubo-api-url, kubo-api-auth), or Filebase (filebase-access-key, filebase-secret-key, filebase-bucket)."
+        # 4. Filecoin (filecoin-pin): wallet key must be set (spend caps validated separately below)
+        # 5. Filebase: access key, secret key, and bucket must all be set
+        if [[ -z "${{ inputs.storacha-key }}" || -z "${{ inputs.storacha-proof }}" ]] && [[ -z "${{ inputs.cluster-url }}" || -z "${{ inputs.cluster-user }}" || -z "${{ inputs.cluster-password }}" ]] && [[ -z "${{ inputs.kubo-api-url }}" || -z "${{ inputs.kubo-api-auth }}" ]] && [[ -z "${{ inputs.filecoin-wallet-key }}" ]] && [[ -z "${{ inputs.filebase-access-key }}" || -z "${{ inputs.filebase-secret-key }}" || -z "${{ inputs.filebase-bucket }}" ]]; then
+          MSG="At least one CAR upload provider must be configured: IPFS Cluster (cluster-url, cluster-user, cluster-password), Kubo (kubo-api-url, kubo-api-auth), Filecoin (filecoin-wallet-key + filecoin-min-runway-days + filecoin-max-balance), or Filebase (filebase-access-key, filebase-secret-key, filebase-bucket)."
           if [[ -n "${{ inputs.pinata-jwt-token }}" ]]; then
             MSG="${MSG} Pinata cannot be the sole provider until CAR upload support is tested (see https://github.com/ipshipyard/ipfs-deploy-action/pull/42)."
           fi
@@ -118,6 +136,16 @@ runs:
         # Warn about Storacha service shutdown
         if [[ -n "${{ inputs.storacha-key }}" && -n "${{ inputs.storacha-proof }}" ]]; then
           echo "::warning::Storacha uploads will stop working on April 15, 2026. Please switch to an alternative pinning service. Details: https://medium.com/@storacha/an-update-on-storacha-and-important-news-for-you-and-your-data-15a5d10b7da0"
+        fi
+
+        # Filecoin: when wallet key is set, both spend caps must also be set.
+        # We provide no defaults for the caps so the caller chooses explicitly
+        # (wrong values can drain a wallet).
+        if [[ -n "${{ inputs.filecoin-wallet-key }}" ]]; then
+          if [[ -z "${{ inputs.filecoin-min-runway-days }}" || -z "${{ inputs.filecoin-max-balance }}" ]]; then
+            echo "::error::filecoin-wallet-key requires both filecoin-min-runway-days and filecoin-max-balance to be set explicitly. These cap wallet spend per run; no defaults are provided."
+            exit 1
+          fi
         fi
 
     - name: Setup Kubo CLI
@@ -295,6 +323,47 @@ runs:
           sleep 5
         done
 
+
+    - name: Upload CAR to Filecoin (filecoin-pin)
+      # Block fork PRs from this wallet-spending step: same-repo events only,
+      # so non-maintainer authors cannot trigger USDFC deposits.
+      if: ${{ inputs.filecoin-wallet-key != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) }}
+      shell: bash
+      env:
+        PRIVATE_KEY: ${{ inputs.filecoin-wallet-key }}
+      run: |
+        echo "ℹ️ Uploading CAR with CID ${{ steps.merkleize.outputs.cid }} to Filecoin (${{ inputs.filecoin-network }}) via filecoin-pin"
+
+        # Capture output so we can dump it in the step summary even on failure
+        # (debugging insufficient USDFC, runway, provider issues, etc).
+        EXIT=0
+        npx -y filecoin-pin@${{ inputs.filecoin-pin-version }} import build.car \
+          --${{ inputs.filecoin-network }} \
+          --auto-fund \
+          --min-runway-days ${{ inputs.filecoin-min-runway-days }} \
+          --max-balance ${{ inputs.filecoin-max-balance }} 2>&1 | tee filecoin-pin.log || EXIT=$?
+
+        if [ "$EXIT" -eq 0 ]; then
+          HEADLINE="✅ Uploaded CAR with CID \`${{ steps.merkleize.outputs.cid }}\` to Filecoin (\`${{ inputs.filecoin-network }}\`)"
+          DETAILS_OPEN=""
+        else
+          HEADLINE="❌ Failed to upload CAR with CID \`${{ steps.merkleize.outputs.cid }}\` to Filecoin (\`${{ inputs.filecoin-network }}\`)"
+          DETAILS_OPEN=" open"
+        fi
+
+        {
+          echo "$HEADLINE"
+          echo
+          echo "<details${DETAILS_OPEN}><summary>filecoin-pin output</summary>"
+          echo
+          echo '```'
+          cat filecoin-pin.log
+          echo '```'
+          echo
+          echo '</details>'
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        exit $EXIT
 
     - name: Upload CAR to Filebase
       if: ${{ inputs.filebase-access-key != '' }}


### PR DESCRIPTION
Wires `filecoin-pin import` into action.yml as a peer to IPFS Cluster, Kubo, and Filebase, so setting `filecoin-wallet-key` satisfies the at-least-one-provider gate. 

New inputs:

- `filecoin-wallet-key`: gates the entire upload step.
- `filecoin-network`: defaults to `mainnet`; set `calibnet` for testing.
- `filecoin-min-runway-days`, `filecoin-max-balance`: required when wallet key is set, no defaults. Both cap wallet spend per run; the right value depends on the caller's traffic and budget, so we force an explicit choice rather than picking one that could drain a wallet.
- `filecoin-pin-version`: pinned to `0.20.1` (first release with `--min-runway-days` and `--max-balance` on `--auto-fund`).
- should we add / expose anything else?

This is alternative to ipshipyard/ipfs-deploy-action#49 (docs-only composition recipe). TBD which one is chosen -- cc @biglep @rvagg @sgtpooki for  visibility and feedback, 

> [!IMPORTANT]
> I'm not a fan of this as it is just wrapping and shifting maintenance cost, triaging bug reports to this repo, instead of the repo where filecoin-pin CLI lives.

---- 

- Closes https://github.com/ipshipyard/ipfs-deploy-action/issues/39